### PR TITLE
Gitignore `Cargo.lock` and `target`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 npm-debug.log
 build/
 node_modules/
+
+Cargo.lock
+target/


### PR DESCRIPTION
This adds two recommended ignores for Rust, namely `Cargo.lock` (which libraries are encouraged to ignore) and `target` (the folder for generated build artifacts).